### PR TITLE
Allow overriding RETRY_COUNT from the environment

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,7 @@ set +x
 
 RETCODE_SUCCESS=0
 RETCODE_ERROR=1
-RETRY_COUNT=5
+RETRY_COUNT=${RETRY_COUNT:-5}
 
 _log() {
   local -r prefix="$1"


### PR DESCRIPTION
This could probably be made smarter, so that permanent failures (like 404) are outright failures.  In the meantime, allow overriding the retry count to prevent hammering the download servers.