### PR TITLE
Make cos-gpu-installer be compatible with COS m66+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ LABEL maintainer="cos-containers@google.com"
 
 # Install minimal tools needed to build kernel modules.
 RUN apt-get update -qq && \
-    apt-get install -y xz-utils python2.7-minimal kmod git make bc curl ccache libc6-dev pciutils gcc && \
+    apt-get install -y xz-utils python2.7-minimal kmod git make bc curl ccache libc6-dev pciutils gcc libelf-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Download & install prebuild COS toolchain package, and prepare the environment for cross-compiling.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,7 +83,7 @@ configure_kernel_module_locking() {
 
     pushd "${mount_path}"
     cp "${grub_cfg}" "${grub_cfg}.orig"
-    sed 's/cros_efi/cros_efi lsm.module_locking=0/g' \
+    sed 's/cros_efi/cros_efi lsm.module_locking=0 loadpin.enabled=0/g' \
       -i "efi/boot/grub.cfg"
     popd
     sync


### PR DESCRIPTION
Starting from milestone 66, COS updated kernel to v4.14. This commit
makes cos-gpu-installer be compatible with the new kernel.