### PR TITLE
Save installer script and env file to stateful partition

### DIFF
--- a/install-test-gpu.cfg
+++ b/install-test-gpu.cfg
@@ -27,8 +27,12 @@ write_files:
       User=root
       Type=oneshot
       RemainAfterExit=true
-      ExecStartPre=/bin/bash -c "/usr/share/google/get_metadata_value attributes/run-installer-script > /tmp/run_installer.sh"
-      ExecStart=/bin/bash /tmp/run_installer.sh
+      # The default stateful path to store user provided installer script and
+      # provided environment variables.
+      Environment=STATEFUL_PATH=/var/lib/nvidia
+      ExecStartPre=/bin/mkdir -p ${STATEFUL_PATH}
+      ExecStartPre=/bin/bash -c "/usr/share/google/get_metadata_value attributes/run-installer-script > /tmp/run_installer.sh && cp -f /tmp/run_installer.sh ${STATEFUL_PATH}/run_installer.sh || true"
+      ExecStart=/bin/bash ${STATEFUL_PATH}/run_installer.sh
       StandardOutput=journal+console
       StandardError=journal+console
 


### PR DESCRIPTION
This will be useful if someone want to run instances from an image
snapshot of the instance that already has gpu driver installed in
the sense that they dont't need to provide env file and installer
script again.