### PR TITLE
Entrypoint.sh: fix issue with download url format that changed again for >=396.37.

### DIFF
--- a/cos-gpu-installer-docker/entrypoint.sh
+++ b/cos-gpu-installer-docker/entrypoint.sh
@@ -264,6 +264,10 @@ major_version() {
   echo "$1" | cut -d "." -f 1
 }
 
+minor_version() {
+  echo "$1" | cut -d "." -f 2
+}
+
 installer_default_download_url() {
   if (( $(major_version "${NVIDIA_DRIVER_VERSION}") < 390 )); then
     # Versions prior to 390 are downloaded from the upstream location.
@@ -283,6 +287,9 @@ installer_default_download_url() {
   if (( $(major_version "${NVIDIA_DRIVER_VERSION}") == 390 )); then
     # The naming format changed after version 390.
     echo "https://storage.googleapis.com/nvidia-drivers-${download_location}-public/TESLA/NVIDIA-Linux-x86_64-${NVIDIA_DRIVER_VERSION}.run"
+  elif (( $(major_version "${NVIDIA_DRIVER_VERSION}") >= 396 )) && (( $(minor_version "${NVIDIA_DRIVER_VERSION}") >= 37 )); then
+    # Apparently the naming format changed again starting since 396.37.
+    echo "https://storage.googleapis.com/nvidia-drivers-${download_location}-public/tesla/${NVIDIA_DRIVER_VERSION}/NVIDIA-Linux-x86_64-${NVIDIA_DRIVER_VERSION}.run"
   else
     echo "https://storage.googleapis.com/nvidia-drivers-${download_location}-public/tesla/${NVIDIA_DRIVER_VERSION}/NVIDIA-Linux-x86_64-${NVIDIA_DRIVER_VERSION}-diagnostic.run"
   fi


### PR DESCRIPTION
Otherwise it fails to install drivers version 396.37 which are needed for CUDA 9.2:

```
[INFO    2018-08-03 19:59:32 UTC] Downloading Nvidia installer from https://storage.googleapis.com/...
[INFO    2018-08-03 19:59:33 UTC] Downloading from https://storage.googleapis.com/nvidia-drivers-us-public/tesla/396.37/NVIDIA-Linux-x86_64-396.37-diagnostic.run
[INFO    2018-08-03 19:59:33 UTC] Downloading Nvidia installer from https://storage.googleapis.com/...
[INFO    2018-08-03 19:59:33 UTC] Downloading Nvidia installer from https://storage.googleapis.com/...
INTEGRITY_RULE file="/usr/bin/md5sum" hash="sha256:08c9ecb479710c1a5f548bf48b722c7ef03054a1741116ae0794df49a5fbb9d4" ppid=1688 pid=1771 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none)
md5sum: WARNING: 1 computed checksum did NOT matchNVIDIA-Linux-x86_64-396.37-diagnostic.run: FAILED
```

Also see the structure of GCS bucket:

```
$ gsutil ls -R gs://nvidia-drivers-us-public/tesla/
gs://nvidia-drivers-us-public/tesla/:

gs://nvidia-drivers-us-public/tesla/396.26/:
gs://nvidia-drivers-us-public/tesla/396.26/NVIDIA-Linux-x86_64-396.26-diagnostic.run
gs://nvidia-drivers-us-public/tesla/396.26/NVIDIA-Linux-x86_64-396.26-diagnostic.run.sha256
gs://nvidia-drivers-us-public/tesla/396.26/NVIDIA-Linux-x86_64-396.26-diagnostic.run.us-public.gcmanifest

gs://nvidia-drivers-us-public/tesla/396.37/:
gs://nvidia-drivers-us-public/tesla/396.37/NVIDIA-Linux-x86_64-396.37.run
gs://nvidia-drivers-us-public/tesla/396.37/NVIDIA-Linux-x86_64-396.37.run.gcmanifest
gs://nvidia-drivers-us-public/tesla/396.37/NVIDIA-Linux-x86_64-396.37.run.sha256
```

The same file can be downloaded from the upstream via http://www.nvidia.com/download/driverResults.aspx/135841/en-us

