### PR TITLE
Add libssl-dev as a dependency

### DIFF
--- a/cos-gpu-installer-docker/Dockerfile
+++ b/cos-gpu-installer-docker/Dockerfile
@@ -19,7 +19,7 @@ LABEL maintainer="cos-containers@google.com"
 
 # Install minimal tools needed to build kernel modules.
 RUN apt-get update -qq && \
-    apt-get install -y xz-utils python2.7-minimal kmod git make bc curl ccache libc6-dev pciutils gcc libelf-dev && \
+    apt-get install -y xz-utils python2.7-minimal kmod git make bc curl ccache libc6-dev pciutils gcc libelf-dev libssl-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Download & install prebuild COS toolchain package, and prepare the environment for cross-compiling.


### PR DESCRIPTION
Package libssl-dev is needed when compile COS kernel with module signing
enabled.