### PR TITLE
Use compilation environment from toolchain_info

### DIFF
--- a/cos-gpu-installer-docker/Dockerfile
+++ b/cos-gpu-installer-docker/Dockerfile
@@ -19,7 +19,8 @@ LABEL maintainer="cos-containers@google.com"
 
 # Install minimal tools needed to build kernel modules.
 RUN apt-get update -qq && \
-    apt-get install -y xz-utils python2.7-minimal kmod git make bc curl ccache libc6-dev pciutils gcc libelf-dev libssl-dev && \
+    apt-get install -y xz-utils python2.7-minimal kmod git make bc curl ccache \
+	libc6-dev pciutils gcc libelf-dev libssl-dev bison flex && \
     rm -rf /var/lib/apt/lists/*
 
 # Download & install prebuild COS toolchain package, and prepare the environment for cross-compiling.


### PR DESCRIPTION
Set compilation environment using toolchain_info
    
toolchain_info contains information about the compiler used for kernel compilation