### PR TITLE
Add support for pre-compiled gpu installer

### DIFF
--- a/cos-gpu-installer-docker/Dockerfile
+++ b/cos-gpu-installer-docker/Dockerfile
@@ -26,5 +26,6 @@ RUN apt-get update -qq && \
 RUN cd /usr/bin && ln -s python2.7 python && ln -s python2.7 python2
 
 COPY README.container /README
+COPY gpu_installer_url_lib.sh /gpu_installer_url_lib.sh
 COPY entrypoint.sh /entrypoint.sh
 CMD /entrypoint.sh

--- a/cos-gpu-installer-docker/gpu_installer_url_lib.sh
+++ b/cos-gpu-installer-docker/gpu_installer_url_lib.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+GPU_INSTALLER_DOWNLOAD_URL=""
+
+get_major_version() {
+  echo "$1" | cut -d "." -f 1
+}
+
+get_minor_version() {
+  echo "$1" | cut -d "." -f 2
+}
+
+get_download_location() {
+  # projects/000000000000/zones/us-west1-a -> us
+  local -r instance_location="$(curl -sfS "http://metadata.google.internal/computeMetadata/v1/instance/zone" -H "Metadata-Flavor: Google" | cut -d '/' -f4 | cut -d '-' -f1)"
+  declare -A location_mapping
+  location_mapping=( ["us"]="us" ["asia"]="asia" ["europe"]="eu" )
+  # Use us as default download location.
+  echo "${location_mapping[${instance_location}]:-us}"
+}
+
+precompiled_installer_download_url() {
+  local -r driver_version="$1"
+  local -r milestone="$2"
+  local -r build_id="${3//\./-}"  # 11895.86.0 -> 11895-86-0
+  local -r major_version="$(get_major_version "${driver_version}")"
+  local -r minor_version="$(get_minor_version "${driver_version}")"
+  local -r download_location="$(get_download_location)"
+
+  echo "https://storage.googleapis.com/nvidia-drivers-${download_location}-public/nvidia-cos-project/${milestone}/tesla/${major_version}_00/${driver_version}/NVIDIA-Linux-x86_64-${driver_version}_${milestone}-${build_id}.cos"
+}
+
+default_installer_download_url() {
+  local -r driver_version="$1"
+  local -r major_version="$(get_major_version "${driver_version}")"
+  local -r minor_version="$(get_minor_version "${driver_version}")"
+  local -r download_location="$(get_download_location)"
+
+  if (( "${major_version}" < 390 )); then
+    # Versions prior to 390 are downloaded from the upstream location.
+    echo "https://us.download.nvidia.com/tesla/${driver_version}/NVIDIA-Linux-x86_64-${driver_version}.run"
+  elif (( "${major_version}" == 390 )); then
+    # The naming format changed after version 390.
+    echo "https://storage.googleapis.com/nvidia-drivers-${download_location}-public/TESLA/NVIDIA-Linux-x86_64-${driver_version}.run"
+  elif (( "${major_version}" >= 396 )) && (( "${minor_version}" >= 37 )); then
+    # Apparently the naming format changed again starting since 396.37.
+    echo "https://storage.googleapis.com/nvidia-drivers-${download_location}-public/tesla/${driver_version}/NVIDIA-Linux-x86_64-${driver_version}.run"
+  else
+    echo "https://storage.googleapis.com/nvidia-drivers-${download_location}-public/tesla/${driver_version}/NVIDIA-Linux-x86_64-${driver_version}-diagnostic.run"
+  fi
+}
+
+get_gpu_installer_url() {
+  if [[ -z "${GPU_INSTALLER_DOWNLOAD_URL}" ]]; then
+    # First try to find the precompiled gpu installer.
+    local -r url="$(precompiled_installer_download_url "$@")"
+    if curl -s -I "${url}"  2>&1 | grep -q 'HTTP/2 200'; then
+      GPU_INSTALLER_DOWNLOAD_URL="${url}"
+    else
+      # Fallback to default gpu installer.
+      GPU_INSTALLER_DOWNLOAD_URL="$(default_installer_download_url "$@")"
+    fi
+  fi
+  echo "${GPU_INSTALLER_DOWNLOAD_URL}"
+}


### PR DESCRIPTION
If pre-compiled gpu installer is found, then skip the step of downloading and configuring kernel sources.