### PR TITLE
Make md5sum of generated kernel module consistent

### DIFF
--- a/cos-gpu-installer-docker/entrypoint.sh
+++ b/cos-gpu-installer-docker/entrypoint.sh
@@ -409,8 +409,12 @@ configure_nvidia_installation_dirs() {
 run_nvidia_installer() {
   info "Running Nvidia installer"
   pushd "${NVIDIA_INSTALL_DIR_CONTAINER}"
+  local -r dir_to_extract="/tmp/extract"
+  # Extract files to a fixed path first to make sure md5sum of generated gpu
+  # drivers are consistent.
+  sh "${INSTALLER_FILE}" -x --target "${dir_to_extract}"
   if is_precompiled_installer; then
-    sh "${INSTALLER_FILE}" \
+    "${dir_to_extract}/nvidia-installer" \
       --utility-prefix="${NVIDIA_INSTALL_DIR_CONTAINER}" \
       --opengl-prefix="${NVIDIA_INSTALL_DIR_CONTAINER}" \
       --no-install-compat32-libs \
@@ -418,7 +422,7 @@ run_nvidia_installer() {
       --silent \
       --accept-license
   else
-    sh "${INSTALLER_FILE}" \
+    "${dir_to_extract}/nvidia-installer" \
       --kernel-source-path="${KERNEL_SRC_DIR}" \
       --utility-prefix="${NVIDIA_INSTALL_DIR_CONTAINER}" \
       --opengl-prefix="${NVIDIA_INSTALL_DIR_CONTAINER}" \


### PR DESCRIPTION
This PR makes the generated kernel module have consistent
md5sum accross different runs.