### PR TITLE
Allow cos-gpu-installer to sign gpu drivers

### DIFF
--- a/cos-gpu-installer-docker/Dockerfile
+++ b/cos-gpu-installer-docker/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer="cos-containers@google.com"
 # Install minimal tools needed to build kernel modules.
 RUN apt-get update -qq && \
     apt-get install -y xz-utils python2.7-minimal kmod git make bc curl ccache \
-    libc6-dev pciutils gcc libelf-dev libssl-dev bison flex && \
+    libc6-dev pciutils gcc libelf-dev libssl-dev bison flex keyutils && \
     rm -rf /var/lib/apt/lists/*
 
 # Download & install prebuild COS toolchain package, and prepare the environment for cross-compiling.
@@ -28,5 +28,7 @@ RUN cd /usr/bin && ln -s python2.7 python && ln -s python2.7 python2
 
 COPY README.container /README
 COPY gpu_installer_url_lib.sh /gpu_installer_url_lib.sh
+COPY driver_signature_lib.sh /driver_signature_lib.sh
+COPY sign_gpu_driver.sh /sign_gpu_driver.sh
 COPY entrypoint.sh /entrypoint.sh
 CMD /entrypoint.sh

--- a/cos-gpu-installer-docker/driver_signature_lib.sh
+++ b/cos-gpu-installer-docker/driver_signature_lib.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+readonly GPU_DRIVER_SIGNATURE="gpu-driver-signature.tar.gz"
+readonly GPU_PRECOMPILED_DRIVER_SIGNATURE="gpu-precompiled-driver-signature.tar.gz"
+readonly GPU_DRIVER_PUBLIC_KEY_PEM="gpu-driver-cert.pem"
+readonly GPU_DRIVER_PUBLIC_KEY_DER="gpu-driver-cert.der"
+readonly GPU_DRIVER_PRIVATE_KEY="dummy-key"
+readonly GPU_DRIVER_SIGNING_DIR="/build/sign-gpu-driver"
+
+download_artifact_from_gcs() {
+  local -r gcs_bucket="$1"
+  local -r build_id="$2"
+  local -r filename="$3"
+  local -r download_url="${gcs_bucket}/${build_id}/${filename}"
+  local -r output_path="${GPU_DRIVER_SIGNING_DIR}/${filename}"
+
+  download_content_from_url "${download_url}" "${output_path}" "${filename}"
+}
+
+download_driver_signature() {
+  local -r gcs_bucket="$1"
+  local -r build_id="$2"
+
+  mkdir -p "${GPU_DRIVER_SIGNING_DIR}"
+  # Try to Download GPU driver signature. If fail then return immediately to
+  # reduce latency because in such case precompiled GPU driver signature must
+  # not exist.
+  download_artifact_from_gcs "${gcs_bucket}" "${build_id}" "${GPU_DRIVER_SIGNATURE}" || return 0
+  # Try to download precompiled GPU driver signature
+  download_artifact_from_gcs "${gcs_bucket}" "${build_id}" "${GPU_PRECOMPILED_DRIVER_SIGNATURE}" || true
+}
+
+has_driver_signature() {
+  [[ -f "${GPU_DRIVER_SIGNING_DIR}/${GPU_DRIVER_SIGNATURE}" ]]
+}
+
+has_precompiled_driver_signature() {
+  [[ -f "${GPU_DRIVER_SIGNING_DIR}/${GPU_PRECOMPILED_DRIVER_SIGNATURE}" ]]
+}
+
+decompress_driver_signature() {
+  if ! has_driver_signature && ! has_precompiled_driver_signature; then
+    return 1
+  fi
+
+  pushd "${GPU_DRIVER_SIGNING_DIR}" || return 1
+  if has_precompiled_driver_signature; then
+    tar xzf "${GPU_PRECOMPILED_DRIVER_SIGNATURE}"
+  elif has_driver_signature; then
+    tar xzf "${GPU_DRIVER_SIGNATURE}"
+  fi
+  popd || return 1
+
+  # Create a dummy private key. We don't need private key to sign the driver
+  # because we already have the signature.
+  touch "${GPU_DRIVER_SIGNING_DIR}/${GPU_DRIVER_PRIVATE_KEY}"
+}
+
+get_private_key() {
+  echo "${GPU_DRIVER_SIGNING_DIR}/${GPU_DRIVER_PRIVATE_KEY}"
+}
+
+get_public_key_pem() {
+  echo "${GPU_DRIVER_SIGNING_DIR}/${GPU_DRIVER_PUBLIC_KEY_PEM}"
+}
+
+load_public_key() {
+  info "Loading GPU driver public key to system keyring."
+  /bin/keyctl padd asymmetric "gpu_key" \
+    %keyring:.secondary_trusted_keys < \
+    "${GPU_DRIVER_SIGNING_DIR}/${GPU_DRIVER_PUBLIC_KEY_DER}"
+}

--- a/cos-gpu-installer-docker/gpu_installer_url_lib.sh
+++ b/cos-gpu-installer-docker/gpu_installer_url_lib.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+source driver_signature_lib.sh
 
 GPU_INSTALLER_DOWNLOAD_URL=""
 
@@ -54,7 +71,10 @@ get_gpu_installer_url() {
   if [[ -z "${GPU_INSTALLER_DOWNLOAD_URL}" ]]; then
     # First try to find the precompiled gpu installer.
     local -r url="$(precompiled_installer_download_url "$@")"
-    if curl -s -I "${url}"  2>&1 | grep -q 'HTTP/2 200'; then
+    # Only download pre-compiled driver if both installer and the corresponding
+    # signature exist.
+    if curl -s -I "${url}"  2>&1 | grep -q 'HTTP/2 200' && \
+      has_precompiled_driver_signature; then
       GPU_INSTALLER_DOWNLOAD_URL="${url}"
     else
       # Fallback to default gpu installer.

--- a/cos-gpu-installer-docker/sign_gpu_driver.sh
+++ b/cos-gpu-installer-docker/sign_gpu_driver.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+assert_file_exists() {
+  if [[ ! -f ${1} ]]; then
+    exit 1
+  fi
+}
+
+sign_gpu_driver() {
+  local -r hash_algo="$1"
+  # private key is a dummy key. It is not needed in this script as we already
+  # have the signature.
+  #local -r priv_key="$2"
+  local -r pub_key="$3"
+  local -r module="$4"
+  # sign-file is used to attach driver signature to gpu driver to generate a
+  # signed driver. It is compiled from scripts/sign-file.c of Linux kernel
+  # source code. COS team provide it along with gpu driver signature to make
+  # sure the sign-file matches the kernel of COS version.
+  local -r sign_file="$(dirname "${pub_key}")"/sign-file
+  local -r signature="$(dirname "${pub_key}")/$(basename "${module}")".sig
+
+  assert_file_exists "${pub_key}"
+  assert_file_exists "${module}"
+  assert_file_exists "${sign_file}"
+  assert_file_exists "${signature}"
+
+  chmod +x "${sign_file}"
+
+  "${sign_file}" -s "${signature}" "${hash_algo}" "${pub_key}" "${module}"
+}
+
+sign_gpu_driver "$@"


### PR DESCRIPTION
This PR:
1) Adds functions to download and decompress GPU driver signatures;
2) Asks nvidia_installer.run to sign drivers and precompiled drivers if signature is found
3) Adds /sign_gpu_driver.sh which will be invoked by nvidia_installer.run to the actual signing. GPU driver is signed through attaching standalone signature to the end of the driver. 
4) Adds GCE service account credentials for download_content_from_url
5) Uses download_content_from_url for all downloading

Note that after this change, pre-compiled GPU driver will only be used if the corresponding signature also exist.