### PR TITLE
add support for display driver

### DIFF
--- a/cos-gpu-installer-docker/entrypoint.sh
+++ b/cos-gpu-installer-docker/entrypoint.sh
@@ -417,6 +417,8 @@ run_nvidia_installer() {
     "${dir_to_extract}/nvidia-installer" \
       --utility-prefix="${NVIDIA_INSTALL_DIR_CONTAINER}" \
       --opengl-prefix="${NVIDIA_INSTALL_DIR_CONTAINER}" \
+      --x-prefix="${NVIDIA_INSTALL_DIR_CONTAINER}" \
+      --install-libglvnd \
       --no-install-compat32-libs \
       --log-file-name="${NVIDIA_INSTALL_DIR_CONTAINER}/nvidia-installer.log" \
       --silent \
@@ -426,6 +428,8 @@ run_nvidia_installer() {
       --kernel-source-path="${KERNEL_SRC_DIR}" \
       --utility-prefix="${NVIDIA_INSTALL_DIR_CONTAINER}" \
       --opengl-prefix="${NVIDIA_INSTALL_DIR_CONTAINER}" \
+      --x-prefix="${NVIDIA_INSTALL_DIR_CONTAINER}" \
+      --install-libglvnd \
       --no-install-compat32-libs \
       --log-file-name="${NVIDIA_INSTALL_DIR_CONTAINER}/nvidia-installer.log" \
       --silent \
@@ -446,6 +450,9 @@ configure_cached_installation() {
   if ! lsmod | grep -q -w 'nvidia_drm'; then
     insmod "${NVIDIA_INSTALL_DIR_CONTAINER}/drivers/nvidia-drm.ko"
   fi
+  if ! lsmod | grep -q -w 'nvidia_modeset'; then
+    insmod "${NVIDIA_INSTALL_DIR_CONTAINER}/drivers/nvidia-modeset.ko"
+  fi
 }
 
 verify_nvidia_installation() {
@@ -453,7 +460,7 @@ verify_nvidia_installation() {
   export PATH="${NVIDIA_INSTALL_DIR_CONTAINER}/bin:${PATH}"
   nvidia-smi
   # Create unified memory device file.
-  nvidia-modprobe -c0 -u
+  nvidia-modprobe -c0 -u -m
 
   # TODO: Add support for enabling persistence mode.
 }


### PR DESCRIPTION
This adds support for running graphics applications on GKE with the NVIDIA driver.

The following changes were required:
 - Add `--x-prefix` and `--install-libglvnd` to the installer args.
 - Add `-m` argument to `nvidia-modprobe` to install the `nvidia-modeset.ko` kernel module.