### PR TITLE
Avoid repeated sourcing of driver_signature_lib.sh

### DIFF
--- a/cos-gpu-installer-docker/gpu_installer_url_lib.sh
+++ b/cos-gpu-installer-docker/gpu_installer_url_lib.sh
@@ -15,8 +15,6 @@
 # limitations under the License.
 
 
-source driver_signature_lib.sh
-
 GPU_INSTALLER_DOWNLOAD_URL=""
 
 get_major_version() {


### PR DESCRIPTION
This PR removes sourcing driver_signature_lib.sh in
gpu_installer_url_lib.sh. It causes the problem that
driver_signature_lib.sh was sourced twice in entrypoint.sh which
makes readonly variables to be assigned again which results in
errors.