### PR TITLE
Use the kernel source repository path from `kernel_info` file

### DIFF
--- a/cos-gpu-installer-docker/Dockerfile
+++ b/cos-gpu-installer-docker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Dockerfile for the COS Module Builder container.
+# Dockerfile for the COS GPU Installer container.
 
 FROM debian:9
 LABEL maintainer="cos-containers@google.com"


### PR DESCRIPTION
This CL includes following changes:
  1. Get the kernel source repository path from kernel_info file if
     present.
  2. Remove repititive source of driver_signature_lib.sh
  3. Fix typo in Dockerfile