### PR TITLE
Update default GPU driver version to 440.64.00

### DIFF
--- a/cos-gpu-installer-docker/gpu_installer_url_lib.sh
+++ b/cos-gpu-installer-docker/gpu_installer_url_lib.sh
@@ -15,8 +15,6 @@
 # limitations under the License.
 
 
-source driver_signature_lib.sh
-
 GPU_INSTALLER_DOWNLOAD_URL=""
 
 get_major_version() {
@@ -71,10 +69,7 @@ get_gpu_installer_url() {
   if [[ -z "${GPU_INSTALLER_DOWNLOAD_URL}" ]]; then
     # First try to find the precompiled gpu installer.
     local -r url="$(precompiled_installer_download_url "$@")"
-    # Only download pre-compiled driver if both installer and the corresponding
-    # signature exist.
-    if curl -s -I "${url}"  2>&1 | grep -q 'HTTP/2 200' && \
-      has_precompiled_driver_signature; then
+    if curl -s -I "${url}"  2>&1 | grep -q 'HTTP/2 200'; then
       GPU_INSTALLER_DOWNLOAD_URL="${url}"
     else
       # Fallback to default gpu installer.

--- a/scripts/gpu-installer-env
+++ b/scripts/gpu-installer-env
@@ -1,7 +1,7 @@
 # Change or Uncomment following variables if you need to install
 # a different gpu driver version, install to different location, etc.
 
-NVIDIA_DRIVER_VERSION=418.67
+NVIDIA_DRIVER_VERSION=440.64.00
 # NVIDIA_DRIVER_MD5SUM=662865d9a7b5ef1ac3402e098a5fb91f
 # COS_NVIDIA_INSTALLER_CONTAINER=gcr.io/cos-cloud/cos-gpu-installer:latest
 # NVIDIA_INSTALL_DIR_HOST=/var/lib/nvidia


### PR DESCRIPTION
This PR updated default GPU driver version to 440.64.00 which is requested by a customer. It also removes the support of signed GPU drivers as it will be supported in cos-gpu-installer-v2.