### PR TITLE
Allow specify GPU driver installer download URL through env

### DIFF
--- a/cos-gpu-installer-docker/gpu_installer_url_lib.sh
+++ b/cos-gpu-installer-docker/gpu_installer_url_lib.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-GPU_INSTALLER_DOWNLOAD_URL=""
+GPU_INSTALLER_DOWNLOAD_URL="${GPU_INSTALLER_DOWNLOAD_URL:-}"
 
 get_major_version() {
   echo "$1" | cut -d "." -f 1


### PR DESCRIPTION
This PR adds a new env to specify GPU driver installer download URL
directly. This allows users to installer drivers from a location
other than the default one.