### PR TITLE
Make sure the toolchain is mounted as exec.

### DIFF
--- a/cos-gpu-installer-docker/entrypoint.sh
+++ b/cos-gpu-installer-docker/entrypoint.sh
@@ -349,6 +349,10 @@ install_cross_toolchain_pkg() {
   info "$TOOLCHAIN_PKG_DIR: $(ls -A "${TOOLCHAIN_PKG_DIR}")"
   if [[ ! -z "$(ls -A "${TOOLCHAIN_PKG_DIR}")" ]]; then
     info "Found existing toolchain package. Skipping download and installation"
+    if mountpoint -q "${TOOLCHAIN_PKG_DIR}"; then
+      info "${TOOLCHAIN_PKG_DIR} is a mountpoint; remounting as exec"
+      mount -o remount,exec "${TOOLCHAIN_PKG_DIR}"
+    fi
   else
     mkdir -p "${TOOLCHAIN_PKG_DIR}"
     pushd "${TOOLCHAIN_PKG_DIR}"


### PR DESCRIPTION
If someone bind mounts a toolchain into /build/cos-tools from a COS
host, chances are that the bind mount will be noexec (since the source
mount of that bind mount will likely be noexec). Since we need to
execute the toolchain, let's remount it as exec.

Tested by running cos-gpu-installer with a preloaded toolchain in
/var/lib/cos-tools, bind mounted inside the container to
/build/cos-tools.