### PR TITLE
Update run_installer.sh

### DIFF
--- a/scripts/run_installer.sh
+++ b/scripts/run_installer.sh
@@ -53,7 +53,8 @@ main() {
     --volume /dev:/dev \
     --volume "/":"${ROOT_MOUNT_DIR}" \
     --env-file "${_GPU_INSTALLER_ENV_PATH}" \
-    "${COS_NVIDIA_INSTALLER_CONTAINER}"
+    "${COS_NVIDIA_INSTALLER_CONTAINER}" \
+    "install"
   # Verify installation.
   ${NVIDIA_INSTALL_DIR_HOST}/bin/nvidia-smi
 }


### PR DESCRIPTION
gcr.io/cos-cloud/cos-gpu-installer:latest requires `install` flag to actually install

The takes care of adding the install flag. A better fix would be to default to install.