### PR TITLE
Reduce disk space usage and improve compile times.

### DIFF
--- a/cos-gpu-installer-docker/Dockerfile
+++ b/cos-gpu-installer-docker/Dockerfile
@@ -19,8 +19,9 @@ LABEL maintainer="cos-containers@google.com"
 
 # Install minimal tools needed to build kernel modules.
 RUN apt-get update -qq && \
-    apt-get install -y xz-utils python2.7-minimal kmod git make bc curl ccache \
-    libc6-dev pciutils gcc libelf-dev libssl-dev bison flex keyutils && \
+    apt-get install -y --no-install-recommends xz-utils python2.7-minimal \
+    libc6-dev libpython2.7-stdlib kmod make curl ca-certificates libssl-dev \
+    gcc libelf-dev keyutils && \
     rm -rf /var/lib/apt/lists/*
 
 # Download & install prebuild COS toolchain package, and prepare the environment for cross-compiling.


### PR DESCRIPTION
Currently, cos-gpu-installer generates a few kernel files that
nvidia modules depend on. However, these generated files are already
pregenerated in our kernel-headers.tgz archive that we already
distribute. By using the kernel-headers.tgz archive instead of the
kernel-source.tar.gz archive, we can drop a few Dockerfile
dependencies needed for generating some kernel files and avoid
downloading the kernel source.

These changes bring the size of the container image down from 366MB to
262MB. We are also saving between 900MB-1GB by not downloading and
extracting the kernel source archive.

Also, the time to install drivers from scratch (no precompiled drivers)
is reduced from ~6m36s to ~5m40s.

The correct kernel headers archives are available for all versions
released after September 2018. This includes all stable versions M73+,
and all stable M69 versions starting with cos-69-10895-71-0. After this
change, users using images before cos-69-10895-71-0 will need to either
upgrade their COS version or pin to an older cos-gpu-installer version.
COS has stopped supporting M69 images a while ago.

Tested on latest M69, M73, M77, M81, M85, dev.