### PR TITLE
Only disable signature verification when module.sig_enforce=1 is set

### DIFF
--- a/cos-gpu-installer-docker/entrypoint.sh
+++ b/cos-gpu-installer-docker/entrypoint.sh
@@ -122,13 +122,9 @@ configure_kernel_module_locking() {
   pushd "${mount_path}"
 
   # Disable kernel module signature verification.
-  if grep -q "module.sig_enforce" /proc/cmdline; then
-    if grep -q "module.sig_enforce=1" /proc/cmdline; then
-      sed_cmds+=('s/module.sig_enforce=1/module.sig_enforce=0/g')
-    fi
-  else
-    sed_cmds+=('s/cros_efi/cros_efi module.sig_enforce=0/g')
-  fi;
+  if grep -q "module.sig_enforce=1" /proc/cmdline; then
+    sed_cmds+=('s/module.sig_enforce=1/module.sig_enforce=0/g')
+  fi
 
   # Disable loadpin.
   if grep -q "loadpin.enabled" /proc/cmdline; then


### PR DESCRIPTION
In the past we disable signatrure verification as long as
module.sig_enforce=0 is not set explicitly. This is not compatible with
older COS milestones when secure boot is enabled. Given that we won't
enable signature verification through kernel config for older COS
milestones, it's safe to assume signature verification is not enabled
as long as module.sig_enforce=1 is not in kernel command line.