### PR TITLE
Don't unpack Rust toolchain elements

### DIFF
--- a/cos-gpu-installer-docker/entrypoint.sh
+++ b/cos-gpu-installer-docker/entrypoint.sh
@@ -329,7 +329,12 @@ install_cross_toolchain_pkg() {
       return ${RETCODE_ERROR}
     fi
 
-    tar xf "${pkg_name}"
+    # Don't unpack Rust toolchain elements because they are not needed and they
+    # use a lot of disk space.
+    tar xf "${pkg_name}" \
+      --exclude='./usr/lib64/rustlib*' \
+      --exclude='./lib/librustc*' \
+      --exclude='./usr/lib64/librustc*'
     rm "${pkg_name}"
     popd
   fi


### PR DESCRIPTION
Rust toolchain elements use a lot of disk space and are not needed for
compiling GPU drivers.

Tested on cos-81 and cos-89 with and without the -p option.