### PR TITLE
Exclude /lib/libstd-* from toolchain

### DIFF
--- a/cos-gpu-installer-docker/entrypoint.sh
+++ b/cos-gpu-installer-docker/entrypoint.sh
@@ -333,7 +333,8 @@ install_cross_toolchain_pkg() {
     tar xf "${pkg_name}" \
       --exclude='./usr/lib64/rustlib*' \
       --exclude='./lib/librustc*' \
-      --exclude='./usr/lib64/librustc*'
+      --exclude='./usr/lib64/librustc*' \
+      --exclude='./lib/libstd-*'
     rm "${pkg_name}"
     popd
   fi


### PR DESCRIPTION
These paths are hard links to the rust standard library. Since we are not
using the rust toolchain here, we can exclude them.