### PR TITLE
Exclude /usr/lib64/libstd-* from toolchain

### DIFF
--- a/cos-gpu-installer-docker/entrypoint.sh
+++ b/cos-gpu-installer-docker/entrypoint.sh
@@ -334,6 +334,7 @@ install_cross_toolchain_pkg() {
       --exclude='./usr/lib64/rustlib*' \
       --exclude='./lib/librustc*' \
       --exclude='./usr/lib64/librustc*' \
+      --exclude='./usr/lib64/libstd-*' \
       --exclude='./lib/libstd-*'
     rm "${pkg_name}"
     popd


### PR DESCRIPTION
These are hard links to the rust standard library on M89.